### PR TITLE
Add new workflow to generate javadoc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: 'temurin'
         java-version: 11
     - name: Cache Gradle packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -22,7 +23,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
     - name: Save built output
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: libs
         path: build/libs

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Set up Checkstyle
       run: sudo apt-get install -y checkstyle
     - name: Run checkstyle

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -3,7 +3,7 @@ name: Gradle Build
 on:
   # Only run for pushes to main branch
   push:
-    branches: ["main"]
+    branches: ["main", "javadoc"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -3,7 +3,7 @@ name: Javadoc
 on:
   # Only run for pushes to main branch
   push:
-    branches: ["main", "javadoc"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,54 @@
+name: Gradle Build
+
+on:
+  # Only run for pushes to main branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11
+    - name: Cache Gradle packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Generate Javadoc with Gradle
+      run: ./gradlew javadoc
+    - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'build/docs/javadoc'
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -39,9 +39,9 @@ jobs:
     - name: Generate Javadoc with Gradle
       run: ./gradlew javadoc
     - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: 'build/docs/javadoc'
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: 'build/docs/javadoc'
   deploy:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,4 +1,4 @@
-name: Gradle Build
+name: Javadoc
 
 on:
   # Only run for pushes to main branch
@@ -29,6 +29,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
+        distribution: 'temurin'
         java-version: 11
     - name: Cache Gradle packages
       uses: actions/cache@v3

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,10 @@ test {
     systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
 }
 
+javadoc {
+    source = sourceSets.main.allJava
+}
+
 // Simulation configuration (e.g. environment variables).
 wpi.sim.addGui().defaultEnabled = true
 wpi.sim.addDriverstation()


### PR DESCRIPTION
Add GitHub workflow to automatically generate the javadoc HTML and publish to GitHub Pages. Also bump version of actions used in the existing workflows.